### PR TITLE
Refactor Auth social features and user credential creation

### DIFF
--- a/auth/auth.test.ts
+++ b/auth/auth.test.ts
@@ -54,7 +54,7 @@ describe("#onAuthStateChange()", () => {
     expect(listener).toHaveBeenCalledWith(credential.user);
   });
 
-  it("doesn't invokes the listener after it's disposed", async () => {
+  it("doesn't invoke the listener after it's disposed", async () => {
     const auth = new MockAuth(app);
     const listener = jest.fn();
     const disposer = auth.onAuthStateChanged(listener);

--- a/auth/auth.test.ts
+++ b/auth/auth.test.ts
@@ -21,6 +21,7 @@ describe("#createUserWithEmailAndPassword()", () => {
     expect(auth.store.add).toHaveBeenCalledWith({
       email: "foo@bar.com",
       password: "password",
+      providerId: firebase.auth.EmailAuthProvider.PROVIDER_ID,
     });
   });
 

--- a/auth/auth.ts
+++ b/auth/auth.ts
@@ -4,7 +4,7 @@ import { SocialSignInMock } from "./social-signin-mock";
 import { User } from "./user";
 import { UserStore } from "./user-store";
 import { AuthSettings } from "./auth-settings";
-import { UserCredential } from "./user-credential";
+import { UserCredential, UserCredentialOptions } from "./user-credential";
 
 export type AuthStateChangeListener = (user: firebase.User | null) => void;
 
@@ -106,14 +106,14 @@ export class MockAuth implements firebase.auth.Auth {
 
   private signIn(
     user: User,
-    { isNewUser }: { isNewUser: boolean }
+    options: UserCredentialOptions
   ): Promise<firebase.auth.UserCredential> {
     this.currentUser = user;
     this.authStateEvents.forEach((listener) => {
       listener(user);
     });
 
-    return Promise.resolve(new UserCredential(user, "signIn", isNewUser));
+    return Promise.resolve(new UserCredential(user, "signIn", options));
   }
 
   private async signInWithSocial(provider: firebase.auth.AuthProvider) {

--- a/auth/auth.ts
+++ b/auth/auth.ts
@@ -117,13 +117,14 @@ export class MockAuth implements firebase.auth.Auth {
   }
 
   private async signInWithSocial(provider: firebase.auth.AuthProvider) {
-    const data = await this.store.consumeSocialMock(provider);
-    let user = this.store.findByProviderAndEmail(data.email, provider.providerId);
+    const mockResponse = await this.store.consumeSocialMock(provider);
+    let user = this.store.findByProviderAndEmail(mockResponse.email, provider.providerId);
     if (user) {
       return this.signIn(user, { isNewUser: false });
     }
 
-    user = this.store.add({ ...data, providerId: provider.providerId });
+    // user didn't exist, so it's created and then signed in
+    user = this.store.add({ ...mockResponse, providerId: provider.providerId });
     return this.signIn(user, { isNewUser: true });
   }
 

--- a/auth/auth.ts
+++ b/auth/auth.ts
@@ -180,8 +180,8 @@ export class MockAuth implements firebase.auth.Auth {
     return this.signInWithSocial(provider);
   }
 
-  async signInWithRedirect(provider: firebase.auth.AuthProvider): Promise<void> {
-    await this.signInWithSocial(provider);
+  signInWithRedirect(provider: firebase.auth.AuthProvider): Promise<void> {
+    throw new Error("Method not implemented.");
   }
 
   signOut(): Promise<void> {

--- a/auth/user-credential.ts
+++ b/auth/user-credential.ts
@@ -1,5 +1,9 @@
 import { User } from "./user";
 
+export interface UserCredentialOptions {
+  isNewUser: boolean;
+}
+
 export class UserCredential implements firebase.auth.UserCredential {
   readonly additionalUserInfo: firebase.auth.AdditionalUserInfo | null = null;
   readonly credential = null;
@@ -7,7 +11,7 @@ export class UserCredential implements firebase.auth.UserCredential {
   constructor(
     readonly user: User,
     readonly operationType: "signIn" | "link" | "reauthenticate",
-    isNewUser: boolean
+    { isNewUser }: UserCredentialOptions
   ) {
     if (!user.isAnonymous) {
       this.additionalUserInfo = {

--- a/auth/user-credential.ts
+++ b/auth/user-credential.ts
@@ -1,0 +1,22 @@
+import { User } from "./user";
+
+export class UserCredential implements firebase.auth.UserCredential {
+  readonly additionalUserInfo: firebase.auth.AdditionalUserInfo | null = null;
+  readonly credential = null;
+
+  constructor(
+    readonly user: User,
+    readonly operationType: "signIn" | "link" | "reauthenticate",
+    isNewUser: boolean
+  ) {
+    if (!user.isAnonymous) {
+      this.additionalUserInfo = {
+        isNewUser,
+        profile: null,
+        // providerId should be at the right value in the user object already.
+        providerId: user.providerId,
+        username: user.email,
+      };
+    }
+  }
+}

--- a/auth/user-store.ts
+++ b/auth/user-store.ts
@@ -1,8 +1,10 @@
 import { User, UserSchema, UserInfo } from "./user";
+import { SocialSignInMock } from "./social-signin-mock";
 
 export class UserStore {
   private nextId = 0;
   private store = new Map<string, UserSchema>();
+  private readonly socialMocks: SocialSignInMock[] = [];
 
   add(data: Partial<UserSchema>): User {
     const uid = ++this.nextId + "";
@@ -18,6 +20,23 @@ export class UserStore {
     const schema = user.toJSON() as UserSchema;
     this.store.set(schema.uid, schema);
     return user;
+  }
+
+  addSocialMock(mock: SocialSignInMock) {
+    this.socialMocks.push(mock);
+  }
+
+  consumeSocialMock(provider: firebase.auth.AuthProvider) {
+    const index = this.socialMocks.findIndex((mock) => mock.type === provider.providerId);
+    if (index === -1) {
+      throw new Error("No mock response set.");
+    }
+
+    // Mock is used, then it must go
+    const mock = this.socialMocks[index];
+    this.socialMocks.splice(index, 1);
+
+    return mock.response;
   }
 
   findByEmail(email: string): User | undefined {

--- a/auth/user-store.ts
+++ b/auth/user-store.ts
@@ -6,11 +6,16 @@ export class UserStore {
   private store = new Map<string, UserSchema>();
   private readonly socialMocks: SocialSignInMock[] = [];
 
+  /**
+   * Adds a user to this store with the given data.
+   * The new user is assigned a new ID and is returned.
+   */
   add(data: Partial<UserSchema>): User {
     const uid = ++this.nextId + "";
     const user = new User(
       {
         ...data,
+        // If the user is being created with a provider ID, then its data is coming from that provider.
         providerData: data.providerId ? [new UserInfo(uid, data.providerId, data)] : [],
         uid,
       },
@@ -26,6 +31,12 @@ export class UserStore {
     this.socialMocks.push(mock);
   }
 
+  /**
+   * Finds the mock response for a given AuthProvider, removes it from the list of mocks
+   * and returns its response.
+   *
+   * If a mock for that AuthProvider is not set, then this method throws.
+   */
   consumeSocialMock(provider: firebase.auth.AuthProvider) {
     const index = this.socialMocks.findIndex((mock) => mock.type === provider.providerId);
     if (index === -1) {

--- a/auth/user-store.ts
+++ b/auth/user-store.ts
@@ -40,13 +40,8 @@ export class UserStore {
   }
 
   findByEmail(email: string): User | undefined {
-    for (const user of this.store.values()) {
-      if (user.email === email) {
-        return new User(user, this);
-      }
-    }
-
-    return undefined;
+    const schema = [...this.store.values()].find((user) => user.email === email);
+    return schema && new User(schema, this);
   }
 
   findByProviderAndEmail(email: string, providerId: string): User | undefined {

--- a/auth/user-store.ts
+++ b/auth/user-store.ts
@@ -1,27 +1,50 @@
-import { User, UserSchema } from "./user";
+import { User, UserSchema, UserInfo } from "./user";
 
 export class UserStore {
   private nextId = 0;
-  private idStore = new Map<string, UserSchema>();
-  private emailStore = new Map<string, UserSchema>();
+  private store = new Map<string, UserSchema>();
 
   add(data: Partial<UserSchema>): User {
     const uid = ++this.nextId + "";
-    const user = new User({ ...data, uid }, this);
+    const user = new User(
+      {
+        ...data,
+        providerData: data.providerId ? [new UserInfo(uid, data.providerId, data)] : [],
+        uid,
+      },
+      this
+    );
 
     const schema = user.toJSON() as UserSchema;
-    this.idStore.set(schema.uid, schema);
-    schema.email && this.emailStore.set(schema.email, schema);
+    this.store.set(schema.uid, schema);
     return user;
   }
 
   findByEmail(email: string): User | undefined {
-    const schema = this.emailStore.get(email);
-    return schema ? new User(schema, this) : undefined;
+    for (const user of this.store.values()) {
+      if (user.email === email) {
+        return new User(user, this);
+      }
+    }
+
+    return undefined;
+  }
+
+  findByProviderAndEmail(email: string, providerId: string): User | undefined {
+    const user = this.findByEmail(email);
+    if (!user) {
+      return undefined;
+    }
+
+    if (user.providerData.some((info) => info.providerId === providerId)) {
+      return new User({ ...user.toJSON(), providerId }, this);
+    }
+
+    throw new Error("auth/account-exists-with-different-credential");
   }
 
   update(id: string, data: Partial<UserSchema>) {
-    const schema = this.idStore.get(id);
+    const schema = this.store.get(id);
     if (!schema) {
       return;
     }

--- a/auth/user.ts
+++ b/auth/user.ts
@@ -28,10 +28,10 @@ export class UserInfo implements firebase.UserInfo {
     readonly providerId: string,
     rest: Partial<Omit<firebase.UserInfo, "uid" | "providerId">>
   ) {
-    this.displayName = rest.displayName || null;
-    this.email = rest.email || null;
-    this.phoneNumber = rest.phoneNumber || null;
-    this.photoURL = rest.photoURL || null;
+    this.displayName = rest.displayName ?? null;
+    this.email = rest.email ?? null;
+    this.phoneNumber = rest.phoneNumber ?? null;
+    this.photoURL = rest.photoURL ?? null;
   }
 }
 

--- a/auth/user.ts
+++ b/auth/user.ts
@@ -7,7 +7,7 @@ export interface UserSchema {
   metadata: firebase.auth.UserMetadata;
   password?: string;
   phoneNumber: string | null;
-  providerData: (firebase.UserInfo | null)[];
+  providerData: UserInfo[];
   refreshToken: string;
   displayName: string | null;
   email: string | null;
@@ -17,7 +17,26 @@ export interface UserSchema {
   tenantId: string | null;
 }
 
+export class UserInfo implements firebase.UserInfo {
+  readonly displayName: string | null;
+  readonly email: string | null;
+  readonly phoneNumber: string | null;
+  readonly photoURL: string | null;
+
+  constructor(
+    readonly uid: string,
+    readonly providerId: string,
+    rest: Partial<Omit<firebase.UserInfo, "uid" | "providerId">>
+  ) {
+    this.displayName = rest.displayName || null;
+    this.email = rest.email || null;
+    this.phoneNumber = rest.phoneNumber || null;
+    this.photoURL = rest.photoURL || null;
+  }
+}
+
 export class User implements firebase.User, UserSchema {
+  readonly uid: string;
   displayName: string | null;
   email: string | null;
   emailVerified: boolean;
@@ -26,11 +45,10 @@ export class User implements firebase.User, UserSchema {
   password?: string;
   phoneNumber: string | null;
   photoURL: string | null;
-  providerData: (firebase.UserInfo | null)[];
+  providerData: UserInfo[];
   providerId: string;
   refreshToken: string;
   tenantId: string | null;
-  uid: string;
   multiFactor: firebase.User.MultiFactorUser;
 
   constructor(data: Partial<UserSchema>, private readonly store: UserStore) {


### PR DESCRIPTION
- It's wasn't possible to have a user be linked with multiple providers, so this is now possible by using [`User#providerData`](https://firebase.google.com/docs/reference/js/firebase.User#providerdata);
- Operations like [`linkWithPopup`](https://firebase.google.com/docs/reference/js/firebase.User#linkwithpopup) happen from the `User` object, so social mocks should be accessible by both it and `Auth`;
- `UserCredential` creation didn't seem very stable with 0ae426767b0d59c93cfac21c65ff67548e3aac89, and to make matters worse there would be some duplication when implementing `User#linkWithPopup`. This is now its own class which takes few and simple arguments.